### PR TITLE
Set vim colorscheme name

### DIFF
--- a/lua/zephyr.lua
+++ b/lua/zephyr.lua
@@ -266,7 +266,7 @@ function zephyr.colorscheme()
   if vim.fn.exists('syntax_on') then
     vim.api.nvim_command('syntax reset')
   end
-  -- vim.g.colors_name = 'zephyr'
+  vim.g.colors_name = 'zephyr'
   vim.o.background = 'dark'
   vim.o.termguicolors = true
 


### PR DESCRIPTION
Currently, with the line in the PR commented out, running `:colorscheme` prints `default` even when the colorscheme is set to zephyr. 