### PR TITLE
set background after setting option

### DIFF
--- a/lua/zephyr.lua
+++ b/lua/zephyr.lua
@@ -266,9 +266,9 @@ function zephyr.colorscheme()
   if vim.fn.exists('syntax_on') then
     vim.api.nvim_command('syntax reset')
   end
-  vim.g.colors_name = 'zephyr'
   vim.o.background = 'dark'
   vim.o.termguicolors = true
+  vim.g.colors_name = 'zephyr'
 
   zephyr.terminal_color()
   local syntax = zephyr.load_syntax()


### PR DESCRIPTION
## Why

A error occurs:

```
Error in packer_compiled: Vim(lua):E5108: Error executing lua [string ":lua"]:15: ...e/nvim/site/pack/packer/start/zephyr-nvim/lua/zephyr.lua:270: Vim(lua):E5108: Error exe
cuting lua [string ":lua"]:1: loop or previous error loading module 'zephyr'
Please check your config for correctness
```

## What
I set the color_name after setting options, then, the error does not occur.