### PR TITLE
More Telescope highlights

### DIFF
--- a/lua/zephyr.lua
+++ b/lua/zephyr.lua
@@ -258,7 +258,11 @@ function zephyr.load_plugin_syntax()
     NvimTreeSpecialFile = {fg=zephyr.fg,bg=zephyr.none,stryle='NONE'};
 
     TelescopeBorder = {fg=zephyr.teal};
-    TelescopePromptBorder = {fg=zephyr.blue}
+    TelescopePromptBorder = {fg=zephyr.blue};
+    TelescopeMatching = {fg=zephyr.teal};
+    TelescopeSelection = {fg=zephyr.yellow,bg=zephyr.bg_highlight,style= 'bold'};
+    TelescopeSelectionCaret = {fg=zephyr.yellow};
+    TelescopeMultiSelection = {fg=zephyr.teal};
   }
   return plugin_syntax
 end


### PR DESCRIPTION
The default colours for matching rows in Telescope results is hard to read:

![image](https://user-images.githubusercontent.com/4325872/111373836-ad925280-869c-11eb-8e80-b2b1ac8bf7c0.png)

This change makes it like:

![image](https://user-images.githubusercontent.com/4325872/111373894-c13db900-869c-11eb-90b6-6e49eea9c5ef.png)

Also changes multi-selection colour so it doesn't clash with the above change. From:

![image](https://user-images.githubusercontent.com/4325872/111374123-08c44500-869d-11eb-8a66-71372d768c05.png)

to:

![image](https://user-images.githubusercontent.com/4325872/111374179-1679ca80-869d-11eb-8ac7-cddb71c5939e.png)
