### PR TITLE
gitsigns.nvim support

### DIFF
--- a/lua/zephyr.lua
+++ b/lua/zephyr.lua
@@ -229,6 +229,10 @@ function zephyr.load_plugin_syntax()
     GitGutterDelete = {fg=zephyr.red};
     GitGutterChangeDelete = {fg=zephyr.violet};
 
+    GitSignsAdd = {fg=zephyr.dark_green};
+    GitSignsChange = {fg=zephyr.blue};
+    GitSignsDelete = {fg=zephyr.red};
+
     SignifySignAdd = {fg=zephyr.dark_green};
     SignifySignChange = {fg=zephyr.blue};
     SignifySignDelete = {fg=zephyr.red};


### PR DESCRIPTION
Currently gitsigns.nvim diff signs don't have any color. This adds the colors for gitsigns.nvim default settings.