### PR TITLE
More gitsigns.nvim colors

### DIFF
--- a/lua/zephyr.lua
+++ b/lua/zephyr.lua
@@ -239,6 +239,10 @@ function zephyr.load_plugin_syntax()
     GitSignsChangeLn = {bg=zephyr.bg_highlight};
     GitSignsDeleteLn = {bg=zephyr.bg1};
 
+    SignifySignAdd = {fg=zephyr.dark_green};
+    SignifySignChange = {fg=zephyr.blue};
+    SignifySignDelete = {fg=zephyr.red};
+
     dbui_tables = {fg=zephyr.blue};
 
     LspDiagnosticsSignError = {fg=zephyr.red};

--- a/lua/zephyr.lua
+++ b/lua/zephyr.lua
@@ -232,10 +232,12 @@ function zephyr.load_plugin_syntax()
     GitSignsAdd = {fg=zephyr.dark_green};
     GitSignsChange = {fg=zephyr.blue};
     GitSignsDelete = {fg=zephyr.red};
-
-    SignifySignAdd = {fg=zephyr.dark_green};
-    SignifySignChange = {fg=zephyr.blue};
-    SignifySignDelete = {fg=zephyr.red};
+    GitSignsAddNr = {fg=zephyr.dark_green};
+    GitSignsChangeNr = {fg=zephyr.blue};
+    GitSignsDeleteNr = {fg=zephyr.red};
+    GitSignsAddLn = {bg=zephyr.bg_popup};
+    GitSignsChangeLn = {bg=zephyr.bg_highlight};
+    GitSignsDeleteLn = {bg=zephyr.bg1};
 
     dbui_tables = {fg=zephyr.blue};
 


### PR DESCRIPTION
Added colors for line highlight and line number highlight from gitsigns.nvim. 
![Screenshot from 2021-04-08 02-41-09](https://user-images.githubusercontent.com/59497019/113990282-e72b2900-9816-11eb-9845-b1a7202ebde7.png)

With the colors I added, added lines have green numbers and the shown highlight, changed lines blue numbers and the shown highlight, and removed lines have red numbers and the shown highlight. Do you have an opinion on what color the line highlights should be? I just used the bg colors that were already in the colorscheme. 