### PR TITLE
Fix QuickFix colors

### DIFF
--- a/lua/zephyr.lua
+++ b/lua/zephyr.lua
@@ -96,12 +96,13 @@ function zephyr.load_syntax()
     CursorColumn = {fg=zephyr.none,bg=zephyr.bg_highlight};
     CursorLine = {fg=zephyr.none,bg=zephyr.bg_highlight};
     LineNr = {fg=zephyr.base4};
+    qfLineNr = {fg=zephyr.cyan};
     CursorLineNr = {fg=zephyr.blue};
     DiffAdd = {fg=zephyr.black,bg=zephyr.dark_green};
     DiffChange = {fg=zephyr.black,bg=zephyr.yellow};
     DiffDelete = {fg=zephyr.black,bg=zephyr.red};
     DiffText = {fg=zephyr.black,bg=zephyr.fg};
-    Directory = {fg=zephyr.cyan,bg=zephyr.none};
+    Directory = {fg=zephyr.blue,bg=zephyr.none};
     ErrorMsg = {fg=zephyr.red,bg=zephyr.none,style='bold'};
     WarningMsg = {fg=zephyr.yellow,bg=zephyr.none,style='bold'};
     ModeMsg = {fg=zephyr.fg,bg=zephyr.none,style='bold'};


### PR DESCRIPTION
The colors in QuickFix didn't look very readable. In this PR I changed Quick colors. I replaced `cyan` for directories (before recent 9667a24b5cf9f2f6675f015c04402cf94f5bffd8 `gray` was used) with `blue` and used `cyan` for QuickFix line numbers instead of gray).
**Before:**
![изображение](https://user-images.githubusercontent.com/22453358/114221283-ca593780-9975-11eb-94b1-c71fd9fe4480.png)
**After:**
![изображение](https://user-images.githubusercontent.com/22453358/114221296-cdecbe80-9975-11eb-940e-caffaf8db542.png)
