### PR TITLE
Make CursorWord less light

### DIFF
--- a/lua/zephyr.lua
+++ b/lua/zephyr.lua
@@ -42,7 +42,6 @@ local zephyr = {
   black = '#000000';
 
   bracket = '#80A0C2';
-  currsor_bg = '#4f5b66';
   none = 'NONE';
 }
 
@@ -263,8 +262,9 @@ function zephyr.load_plugin_syntax()
     LspDiagnosticsUnderlineInformation = {style="undercurl",sp=zephyr.blue};
     LspDiagnosticsUnderlineHint = {style="undercurl",sp=zephyr.cyan};
 
-    CursorWord0 = {bg=zephyr.currsor_bg};
-    CursorWord1 = {bg=zephyr.currsor_bg};
+    CursorWord = {bg=zephyr.base4};
+    CursorWord0 = {bg=zephyr.base4};
+    CursorWord1 = {bg=zephyr.base4};
 
     NvimTreeFolderName = {fg=zephyr.blue};
     NvimTreeRootFolder = {fg=zephyr.red,style='bold'};


### PR DESCRIPTION
I know that such things can be opinionated, but here is what I propose. Feel free to disagree.
Before:
![изображение](https://user-images.githubusercontent.com/22453358/116463909-f6c8eb00-a873-11eb-8efd-3d027ae4f0b9.png)
After:
![изображение](https://user-images.githubusercontent.com/22453358/116463888-efa1dd00-a873-11eb-8ac0-df3beef96fb3.png)

The color is close to that used in VSCode:
![изображение](https://user-images.githubusercontent.com/22453358/116464045-2841b680-a874-11eb-93f7-34a0cd5d6a10.png)


Also I added CursorWord group that used by [nvim-cursorline](https://github.com/yamatsum/nvim-cursorline)