### PR TITLE
[Fix] upgrade lua highlights.scm adapt new treesitter.nvim

### DIFF
--- a/after/queries/lua/highlights.scm
+++ b/after/queries/lua/highlights.scm
@@ -1,3 +1,3 @@
 (nil) @boolean
-(table ["{" "}"] @punctuation.bracket)
+(table_constructor ["{" "}"] @punctuation.bracket)
 (field (identifier) @type)


### PR DESCRIPTION
Flag table has been replaced to table_constructor recently.

https://github.com/nvim-treesitter/nvim-treesitter/commit/c80715f883b8c7963782973b23297c5dec7924be.

The original highlight file will cause the following problems:

https://github.com/glepnir/zephyr-nvim/issues/29